### PR TITLE
Optional TF publishing added again

### DIFF
--- a/launch/multi-boards.launch
+++ b/launch/multi-boards.launch
@@ -23,6 +23,7 @@
 
 	<arg name="boards_config" default="$(find ar_sys)/data/multi/boards.yml" />
 	<arg name="boards_directory" default="$(find ar_sys)/data/multi" />
+    <arg name="publish_tf" default="false" />
 
 
 	<group if="$(arg camera_enable)">
@@ -47,6 +48,7 @@
 		<param name="draw_markers" type="bool" value="$(arg result_draw_markers)" />
 		<param name="draw_markers_cube" type="bool" value="$(arg result_draw_markers_cube)" />
 		<param name="draw_markers_axis" type="bool" value="$(arg result_draw_markers_axis)" />
+        <param name="publish_tf" value="$(arg publish_tf)" />
 	</node>
 
 	<node ns="/" pkg="topic_tools" type="relay" name="ar_multi_boards_relay$(arg uid)" args="/ar_multi_boards$(arg uid)/transform /arsys_multi_boards/transform" />

--- a/launch/single_board.launch
+++ b/launch/single_board.launch
@@ -24,6 +24,7 @@
 	<arg name="board_config" default="$(find ar_sys)/data/single/board.yml" />
 	<arg name="board_frame_id" default="board1" />
 	<arg name="marker_size" default="0.05" />
+    <arg name="publish_tf" default="false" />
 
 
 	<group if="$(arg camera_enable)">
@@ -49,6 +50,7 @@
 		<param name="draw_markers" type="bool" value="$(arg result_draw_markers)" />
 		<param name="draw_markers_cube" type="bool" value="$(arg result_draw_markers_cube)" />
 		<param name="draw_markers_axis" type="bool" value="$(arg result_draw_markers_axis)" />
+        <param name="publish_tf" value="$(arg publish_tf)" />
 	</node>
 
 	<node ns="/" pkg="topic_tools" type="relay" name="ar_single_board_relay$(arg uid)" args="/ar_single_board$(arg uid)/transform /arsys_single_board/transform" />

--- a/src/multi_boards.cpp
+++ b/src/multi_boards.cpp
@@ -41,6 +41,7 @@ class ArSysMultiBoards
 		bool draw_markers;
 		bool draw_markers_cube;
 		bool draw_markers_axis;
+        bool publish_tf;
 		MarkerDetector mDetector;
 		vector<Marker> markers;
 		BoardDetector the_board_detector;
@@ -82,6 +83,7 @@ class ArSysMultiBoards
 			nh.param<bool>("draw_markers", draw_markers, false);
 			nh.param<bool>("draw_markers_cube", draw_markers_cube, false);
 			nh.param<bool>("draw_markers_axis", draw_markers_axis, false);
+            nh.param<bool>("publish_tf", publish_tf, false);
 
 			readFromFile(boards_config.c_str());
 			ROS_INFO("ArSys node started with boards configuration: %s", boards_config.c_str());
@@ -129,6 +131,8 @@ class ArSysMultiBoards
 
 		void image_callback(const sensor_msgs::ImageConstPtr& msg)
 		{
+            static tf::TransformBroadcaster br;
+            
 			if(!cam_info_received) return;
 
 			cv_bridge::CvImagePtr cv_ptr;
@@ -159,6 +163,9 @@ class ArSysMultiBoards
 
 						tf::StampedTransform stampedTransform(transform, msg->header.stamp, msg->header.frame_id, boards[board_index].name);
 
+                        if (publish_tf) 
+                            br.sendTransform(stampedTransform);
+                        
 						geometry_msgs::PoseStamped poseMsg;
 						tf::poseTFToMsg(transform, poseMsg.pose);
 						poseMsg.header.frame_id = msg->header.frame_id;

--- a/src/single_board.cpp
+++ b/src/single_board.cpp
@@ -33,6 +33,7 @@ class ArSysSingleBoard
 		bool draw_markers;
 		bool draw_markers_cube;
 		bool draw_markers_axis;
+        bool publish_tf;
 		MarkerDetector mDetector;
 		vector<Marker> markers;
 		BoardConfiguration the_board_config;
@@ -78,6 +79,7 @@ class ArSysSingleBoard
 			nh.param<bool>("draw_markers", draw_markers, false);
 			nh.param<bool>("draw_markers_cube", draw_markers_cube, false);
 			nh.param<bool>("draw_markers_axis", draw_markers_axis, false);
+            nh.param<bool>("publish_tf", publish_tf, false);
 
 			the_board_config.readFromFile(board_config.c_str());
 
@@ -87,6 +89,8 @@ class ArSysSingleBoard
 
 		void image_callback(const sensor_msgs::ImageConstPtr& msg)
 		{
+            static tf::TransformBroadcaster br;
+            
 			if(!cam_info_received) return;
 
 			cv_bridge::CvImagePtr cv_ptr;
@@ -107,6 +111,9 @@ class ArSysSingleBoard
 					tf::Transform transform = ar_sys::getTf(the_board_detected.Rvec, the_board_detected.Tvec);
 
 					tf::StampedTransform stampedTransform(transform, msg->header.stamp, msg->header.frame_id, board_frame);
+                    
+                    if (publish_tf) 
+                        br.sendTransform(stampedTransform);
 
 					geometry_msgs::PoseStamped poseMsg;
 					tf::poseTFToMsg(transform, poseMsg.pose);


### PR DESCRIPTION
Hi Sahloul,

I need to just publish the position of a marker in TF. These changes allow to do this just by launching the nodes with the correct parameters (publish_tf:=true, result_display:=false).

However, this doesn't work yet because of issue #1 

I think that this change would make the package, which looks very good, easier to embed in other applications.